### PR TITLE
Update Render.cs

### DIFF
--- a/NoteCountRender/Render.cs
+++ b/NoteCountRender/Render.cs
@@ -192,7 +192,7 @@ namespace NoteCountRender
             long limMidiTime = (long)midiTime;
             if (limMidiTime > CurrentMidi.tickLength) limMidiTime = CurrentMidi.tickLength;
 
-            long bar = (long)Math.Floor(limMidiTime / barDivide);
+            long bar = (long)Math.Floor(limMidiTime / barDivide) + 1;
             long maxbar = (long)Math.Floor(CurrentMidi.tickLength / barDivide);
             if (bar > maxbar) bar = maxbar;
 


### PR DESCRIPTION
The first tick is in the first measure.
That's why the original code and `Math.ceiling` are wrong.